### PR TITLE
Logger debug change

### DIFF
--- a/Aurora/include/Aurora/Logging.h
+++ b/Aurora/include/Aurora/Logging.h
@@ -33,9 +33,8 @@ namespace Aurora {
 			Log::Message(severityLevel, formatted);
 		}
 
-		static void Message(LogLevel level, const std::string& message);
-
 	private:
+		static void Message(LogLevel level, const std::string& message);
 		inline static LogCallbackFn s_Callback;
 	};
 
@@ -44,19 +43,19 @@ namespace Aurora {
 
 // LEGEND
 // TRACE	: (White)	Used for value tracing 		
+// DEBUG	: (Cyan)	Used for debugging. Should be removed after debug happend.
 // INFO		: (Green)	Used for Information (System, States...)
 // WARN		: (Yellow)	Used for highlighting of potentially problematic behavior
 // ERROR	: (Red)		Used for broken code paths / results
 // CRITICAL	: (Marked)	Used for big NONOs -> should never be hit
 
-// DEBUG	: (Cyan)	Used for debugging. Should be removed after debug happend.
 
 
 #define AURORA_TRACE(...)		Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_TRACE, __VA_ARGS__)
+#define AURORA_DEBUG(...)	Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_DEBUG, __VA_ARGS__)
 #define AURORA_INFO(...)		Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_INFO, __VA_ARGS__)
 #define AURORA_WARN(...)		Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_WARN, __VA_ARGS__)
 #define AURORA_ERROR(...)		Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_ERROR, __VA_ARGS__)
 #define AURORA_CRITICAL(...)	Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_CRITICAL, __VA_ARGS__)
 													   
-#define AURORA_DEBUG_LOG(...)	Aurora::Log::CombineCallbackArgs(Aurora::LogLevel::ALL_DEBUG, __VA_ARGS__)
 

--- a/Aurora/src/Renderer/Renderer.cpp
+++ b/Aurora/src/Renderer/Renderer.cpp
@@ -23,7 +23,7 @@ namespace Aurora {
 
 
 
-		AURORA_INFO("Renderer initialized");
+		AURORA_TRACE("Renderer initialized");
 	}
 
 
@@ -31,7 +31,7 @@ namespace Aurora {
 	{
 
 
-		AURORA_INFO("Renderer shutdown");
+		AURORA_TRACE("Renderer shutdown");
 	}
 
 }

--- a/Nebula/premake5.lua
+++ b/Nebula/premake5.lua
@@ -42,7 +42,7 @@ project "Nebula"
 		characterset "Unicode"
 	
 	filter "configurations:Debug"
-		defines "SF_DEBUG"
+		defines "STARFIRE_DEBUG"
 		runtime "Debug"
 		symbols "on"
 		
@@ -51,7 +51,7 @@ project "Nebula"
 		}
 		
 	filter "configurations:Release"
-		defines "SF_RELEASE"
+		defines "STARFIRE_RELEASE"
 		runtime "Release"
 		optimize "on"
 		

--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -39,7 +39,7 @@ project "Sandbox"
 		characterset "Unicode"
 	
 	filter "configurations:Debug"
-		defines "SF_DEBUG"
+		defines "STARFIRE_DEBUG"
 		runtime "Debug"
 		symbols "on"
 		
@@ -48,7 +48,7 @@ project "Sandbox"
 		}
 		
 	filter "configurations:Release"
-		defines "SF_RELEASE"
+		defines "STARFIRE_RELEASE"
 		runtime "Release"
 		optimize "on"
 		

--- a/Sandbox/src/SandboxApp.cpp
+++ b/Sandbox/src/SandboxApp.cpp
@@ -11,13 +11,6 @@ namespace Sandbox {
 		SandboxApp(const StarFire::ApplicationSpecification& specs)
 			: Application(specs)
 		{
-			SF_TRACE("LogTest: Trace!");
-			SF_INFO("LogTest: Info!");
-			SF_WARN("LogTest: Warn!");
-			SF_ERROR("LogTest: Error!");
-			SF_CRITICAL("LogTest: Critical!");
-			SF_DEBUG_LOG("LogTest: Debug!");
-
 			PushLayer(new SandboxLayer());
 		}
 

--- a/StarFire/premake5.lua
+++ b/StarFire/premake5.lua
@@ -54,7 +54,7 @@ project "StarFire"
 		characterset "Unicode"
 	
 	filter "configurations:Debug"
-		defines "SF_DEBUG"
+		defines "STARFIRE_DEBUG"
 		runtime "Debug"
 		symbols "on"
 		
@@ -63,7 +63,7 @@ project "StarFire"
 		}
 		
 	filter "configurations:Release"
-		defines "SF_RELEASE"
+		defines "STARFIRE_RELEASE"
 		runtime "Release"
 		optimize "on"
 		

--- a/StarFire/src/Platform/Windows/WindowsWindow.cpp
+++ b/StarFire/src/Platform/Windows/WindowsWindow.cpp
@@ -57,7 +57,7 @@ namespace StarFire{
 				NULL);
 			SF_CORE_ASSERT(m_Window != nullptr, "Failed to create GLFW Window");
 			s_GLFWwindowCount++;
-			SF_CORE_INFO("Created window number {}", s_GLFWwindowCount);
+			SF_CORE_TRACE("Created window number {}", s_GLFWwindowCount);
 			
 
 

--- a/StarFire/src/StarFire/Core/Application.cpp
+++ b/StarFire/src/StarFire/Core/Application.cpp
@@ -14,13 +14,7 @@ namespace StarFire {
 	Application::Application(const ApplicationSpecification& specs)
 		: m_Specification(specs)
 	{
-		SF_CORE_INFO("Application: Starting initialization...");
-		SF_CORE_TRACE("LogTest: Trace!");
-		SF_CORE_INFO("LogTest: Info!");
-		SF_CORE_WARN("LogTest: Warn!");
-		SF_CORE_ERROR("LogTest: Error!");
-		SF_CORE_CRITICAL("LogTest: Critical!");
-		SF_CORE_DEBUG_LOG("LogTest: Debug!");
+		SF_CORE_TRACE("Application: Starting initialization...");
 
 		s_Instance = this;
 
@@ -41,7 +35,7 @@ namespace StarFire {
 		m_Aurora->Init();
 
 
-		SF_CORE_INFO("Application: Finished initialization.");
+		SF_CORE_TRACE("Application: Finished initialization.");
 	}
 	Application::~Application()
 	{
@@ -54,27 +48,27 @@ namespace StarFire {
 
 	void Application::PushOverlay(Layer* overlay)
 	{
-		SF_CORE_WARN("Pushing {}", overlay->GetDebugName());
+		SF_CORE_INFO("Pushing {}", overlay->GetDebugName());
 
 		m_LayerStack.PushOverlay(overlay);
 	}
 
 	void Application::PushLayer(Layer* layer)
 	{
-		SF_CORE_WARN("Pushing {}", layer->GetDebugName());
+		SF_CORE_INFO("Pushing {}", layer->GetDebugName());
 
 		m_LayerStack.PushLayer(layer);
 	}
 
 	void Application::Close()
 	{
-		SF_CORE_INFO("Stopping update loop...");
+		SF_CORE_INFO("Closing...");
 		m_Running = false;
 	}
 
 	void Application::Run()
 	{		
-		SF_CORE_INFO("Starting main loop...");
+		SF_CORE_TRACE("Starting main loop...");
 
 		//temp
 		std::thread appThread(SF_BIND_EVENT_FN(Application::AppLoop));
@@ -85,7 +79,7 @@ namespace StarFire {
 		}
 
 		appThread.join();
-		SF_CORE_INFO("Ending main loop...");	
+		SF_CORE_TRACE("Ending main loop...");	
 	}
 
 	void Application::AppLoop()
@@ -142,7 +136,7 @@ namespace StarFire {
 
 	bool Application::OnWindowClose(WindowCloseEvent& e)
 	{
-		SF_CORE_DEBUG_LOG("Closing window...");
+		SF_CORE_DEBUG("Closing window...");
 		Close();
 		return true;
 	}
@@ -155,7 +149,7 @@ namespace StarFire {
 			return false;
 		}
 		m_Minimized = false;
-		SF_CORE_DEBUG_LOG("Window resize to to [{}|{}]", e.GetWidth(), e.GetHeight());
+		SF_CORE_DEBUG("Window resize to to [{}|{}]", e.GetWidth(), e.GetHeight());
 
 		return false;
 	}
@@ -166,7 +160,7 @@ namespace StarFire {
 		{
 			case Aurora::LogLevel::ALL_TRACE: SF_R_CORE_TRACE(msg); break;
 			case Aurora::LogLevel::ALL_INFO: SF_R_CORE_INFO(msg); break;
-			case Aurora::LogLevel::ALL_DEBUG: SF_R_CORE_DEBUG_LOG(msg); break;
+			case Aurora::LogLevel::ALL_DEBUG: SF_R_CORE_DEBUG(msg); break;
 			case Aurora::LogLevel::ALL_WARN: SF_R_CORE_WARN(msg); break;
 			case Aurora::LogLevel::ALL_ERROR: SF_R_CORE_ERROR(msg); break;
 			case Aurora::LogLevel::ALL_CRITICAL: SF_R_CORE_CRITICAL(msg); break;

--- a/StarFire/src/StarFire/Core/EntryPoint.h
+++ b/StarFire/src/StarFire/Core/EntryPoint.h
@@ -16,20 +16,20 @@ int main(int argc, char** argv)
 	auto app = StarFire::CreateApplication(argc, argv);
 	//SF_PROFILE_END_SESSION();
 
-	SF_CORE_INFO("App creation took {}ms", timer.TimestampMilli());
+	SF_CORE_TRACE("App creation took {}ms", timer.TimestampMilli());
 
 	//SF_PROFILE_BEGIN_SESSION("Running", "profiling/StarFireProfile-Running.json");
 	app->Run();
 	//SF_PROFILE_END_SESSION();
 
-	SF_CORE_INFO("Application ran {}s", timer.Timestamp());
+	SF_CORE_TRACE("Application ran {}s", timer.Timestamp());
 
 	//SF_PROFILE_BEGIN_SESSION("Shutdown", "profiling/StarFireProfile-Shutdown.json");
 	delete app;
 	//SF_PROFILE_END_SESSION();
 
-	SF_CORE_INFO("Application shutdown took {}ms", timer.TimestampMilli());
-	SF_CORE_INFO("Closing application after {}s", timer.ElapsedTime());
+	SF_CORE_TRACE("Application shutdown took {}ms", timer.TimestampMilli());
+	SF_CORE_TRACE("Closing application after {}s", timer.ElapsedTime());
 	StarFire::Log::Shutdown();
 
 #ifdef SF_DEBUG

--- a/StarFire/src/StarFire/Core/Logging.cpp
+++ b/StarFire/src/StarFire/Core/Logging.cpp
@@ -7,38 +7,23 @@ namespace StarFire {
 
 
 	std::shared_ptr<spdlog::logger> Log::s_CoreLogger;
-	std::shared_ptr<spdlog::logger> Log::s_CoreDebugLogger;
 	std::shared_ptr<spdlog::logger> Log::s_ClientLogger;
-	std::shared_ptr<spdlog::logger> Log::s_ClientDebugLogger;
 	std::shared_ptr<spdlog::logger> Log::s_RendererLogger;
-	std::shared_ptr<spdlog::logger> Log::s_RendererDebugLogger;
 
 	void Log::Init()
 	{
 		// %^: start color range; %T:time; %e:ms; %n logger name; %v: message; %$: end color range
 		s_CoreLogger = spdlog::stdout_color_mt("STARFIRE");
-		s_CoreLogger->set_pattern("%^[%T%e] [%n] %v%$");
+		s_CoreLogger->set_pattern("%^[%T%e] [%n] %! [Line:%#] %v%$");
 		s_CoreLogger->set_level(spdlog::level::level_enum::trace);
-		
-		s_CoreDebugLogger = spdlog::stdout_color_mt("STARFIRE - DEBUG");
-		s_CoreDebugLogger->set_pattern("%^[%T%e] %! [Line:%#] %v%$");
-		s_CoreDebugLogger->set_level(spdlog::level::level_enum::debug);
 
 		s_ClientLogger = spdlog::stdout_color_mt("CLIENT");
-		s_ClientLogger->set_pattern("%^[%T%e] [%n] %v%$");
+		s_ClientLogger->set_pattern("%^[%T%e] [%n] %! [Line:%#] %v%$");
 		s_ClientLogger->set_level(spdlog::level::level_enum::trace);
 
-		s_ClientDebugLogger = spdlog::stdout_color_mt("APP - DEBUG");
-		s_ClientDebugLogger->set_pattern("%^[%T%e] %! [Line:%#] %v%$");
-		s_ClientDebugLogger->set_level(spdlog::level::level_enum::debug);
-
 		s_RendererLogger = spdlog::stdout_color_mt("AURORA");
-		s_RendererLogger->set_pattern("%^[%T%e] [%n] %v%$");
+		s_RendererLogger->set_pattern("%^[%T%e] [%n] %! [Line:%#] %v%$");
 		s_RendererLogger->set_level(spdlog::level::level_enum::trace);
-
-		s_RendererDebugLogger = spdlog::stdout_color_mt("AURORA - DEBUG");
-		s_RendererDebugLogger->set_pattern("%^[%T%e] %! [Line:%#] %v%$");
-		s_RendererDebugLogger->set_level(spdlog::level::level_enum::debug);
 
 		SF_CORE_INFO("Initialized spdlog (Version {}.{}.{})", SPDLOG_VER_MAJOR, SPDLOG_VER_MINOR, SPDLOG_VER_PATCH);
 	}

--- a/StarFire/src/StarFire/Core/Logging.h
+++ b/StarFire/src/StarFire/Core/Logging.h
@@ -13,59 +13,52 @@ namespace StarFire {
 		static void Shutdown();
 
 		inline static std::shared_ptr<spdlog::logger>& GetCoreLogger() { return s_CoreLogger; }
-		inline static std::shared_ptr<spdlog::logger>& GetCoreDebugLogger() { return s_CoreDebugLogger; }
 		inline static std::shared_ptr<spdlog::logger>& GetClientLogger() { return s_ClientLogger; }
-		inline static std::shared_ptr<spdlog::logger>& GetClientDebugLogger() { return s_ClientDebugLogger; }
 
 		inline static std::shared_ptr<spdlog::logger>& GetRendererLogger() { return s_RendererLogger; }
-		inline static std::shared_ptr<spdlog::logger>& GetRendererDebugLogger() { return s_RendererDebugLogger; }
 
 	private:
 		static std::shared_ptr<spdlog::logger> s_CoreLogger;
-		static std::shared_ptr<spdlog::logger> s_CoreDebugLogger;
 		static std::shared_ptr<spdlog::logger> s_ClientLogger;
-		static std::shared_ptr<spdlog::logger> s_ClientDebugLogger;
 		static std::shared_ptr<spdlog::logger> s_RendererLogger;
-		static std::shared_ptr<spdlog::logger> s_RendererDebugLogger;
 	};
 
 }
 	
 // LEGEND
 // TRACE	: (White)	Used for value tracing 		
+// DEBUG	: (Cyan)	Used for debugging. Should be removed after debug happend.
 // INFO		: (Green)	Used for Information (System, States...)
 // WARN		: (Yellow)	Used for highlighting of potentially problematic behavior
 // ERROR	: (Red)		Used for broken code paths / results
 // CRITICAL	: (Marked)	Used for big NONOs -> should never be hit
 
-// DEBUG	: (Cyan)	Used for debugging. Should be removed after debug happend.
-
 
 #define SF_CORE_TRACE(...)	SPDLOG_LOGGER_TRACE(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
+#define SF_CORE_DEBUG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
 #define SF_CORE_INFO(...)	SPDLOG_LOGGER_INFO(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
 #define SF_CORE_WARN(...)	SPDLOG_LOGGER_WARN(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
 #define SF_CORE_ERROR(...)	SPDLOG_LOGGER_ERROR(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
 #define SF_CORE_CRITICAL(...)	SPDLOG_LOGGER_CRITICAL(StarFire::Log::GetCoreLogger(), __VA_ARGS__)
 
-#define SF_CORE_DEBUG_LOG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetCoreDebugLogger(), __VA_ARGS__)
 
 
 #define SF_TRACE(...)	SPDLOG_LOGGER_TRACE(StarFire::Log::GetClientLogger(), __VA_ARGS__)
+#define SF_DEBUG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetClientLogger(), __VA_ARGS__)
 #define SF_INFO(...)	SPDLOG_LOGGER_INFO(StarFire::Log::GetClientLogger(), __VA_ARGS__)
 #define SF_WARN(...)	SPDLOG_LOGGER_WARN(StarFire::Log::GetClientLogger(), __VA_ARGS__)
 #define SF_ERROR(...)	SPDLOG_LOGGER_ERROR(StarFire::Log::GetClientLogger(), __VA_ARGS__)
 #define SF_CRITICAL(...)	SPDLOG_LOGGER_CRITICAL(StarFire::Log::GetClientLogger(), __VA_ARGS__)
 
-#define SF_DEBUG_LOG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetClientDebugLogger(), __VA_ARGS__)
 
 
 #define SF_R_CORE_TRACE(...)	SPDLOG_LOGGER_TRACE(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
+#define SF_R_CORE_DEBUG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
 #define SF_R_CORE_INFO(...)	SPDLOG_LOGGER_INFO(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
 #define SF_R_CORE_WARN(...)	SPDLOG_LOGGER_WARN(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
 #define SF_R_CORE_ERROR(...)	SPDLOG_LOGGER_ERROR(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
 #define SF_R_CORE_CRITICAL(...)	SPDLOG_LOGGER_CRITICAL(StarFire::Log::GetRendererLogger(), __VA_ARGS__)
 			
-#define SF_R_CORE_DEBUG_LOG(...)	SPDLOG_LOGGER_DEBUG(StarFire::Log::GetRendererDebugLogger(), __VA_ARGS__)
 
 
 

--- a/StarFire/src/StarFire/Core/Window.cpp
+++ b/StarFire/src/StarFire/Core/Window.cpp
@@ -12,10 +12,10 @@ namespace StarFire {
 	Scope<Window> Window::Create(const WindowSpecification& specs /* = WindowSpecification() */)
 	{
 #ifdef SF_PLATFORM_WINDOWS
-		SF_CORE_INFO("Selecting WindowsWindow");
+		SF_CORE_TRACE("Selecting WindowsWindow");
 		return CreateScope<Platform::WindowsWindow>(specs);
 #else
-		SF_CORE_INFO("No window created");
+		SF_CORE_WARN("No window created");
 		return nullptr;
 #endif
 	}


### PR DESCRIPTION
Core:
- removed debug loggers
- changed format of other loggers to also include class:method+line number
- degraded some SF_CORE_INFO logs to Trace (e.g. Startingh Application, ending run loop etc) and some WARN to INFO (e.g. window close event, layer add...)
- removed the test logs for every level from Application and Sandbox

Building:
- changed SF_DEBUG and SF_RELEASE to STARFIRE_DEBUG and STARFIRE_RELEASE to free SF_DEBUG as macro for logging


Issues:
