### PR TITLE
moved BitField into Substrate, no tests yet

### DIFF
--- a/Nebula/premake5.lua
+++ b/Nebula/premake5.lua
@@ -23,6 +23,7 @@ project "Nebula"
 		"%{wks.location}/StarFire/src",
 		"%{IncludeDir.glm}",
 		"%{IncludeDir.spdlog}",
+		"%{IncludeDir.Substrate}",
 	}
 	
 	links

--- a/Sandbox/premake5.lua
+++ b/Sandbox/premake5.lua
@@ -18,7 +18,8 @@ project "Sandbox"
 		"%{wks.location}/StarFire/src",
 		"%{IncludeDir.glm}",
 		"%{IncludeDir.Aurora}",
-		"%{IncludeDir.spdlog}"
+		"%{IncludeDir.spdlog}",
+		"%{IncludeDir.Substrate}",		
 	}
 	
 	links

--- a/StarFire/src/StarFire.h
+++ b/StarFire/src/StarFire.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "StarFire/Core/Logging.h"
-#include "StarFire/Core/Core.h"
+//Core
 #include "StarFire/Core/Application.h"
-#include "StarFire/Core/Timestep.h"
-
+#include "StarFire/Core/Core.h"
+#include "StarFire/Events/Event.h"
 #include "StarFire/Core/Layer.h"
+#include "StarFire/Core/Logging.h"
 
+
+#include "StarFire/Core/Timestep.h"

--- a/StarFire/src/StarFire/Events/Event.h
+++ b/StarFire/src/StarFire/Events/Event.h
@@ -1,17 +1,16 @@
 #pragma once
-#include "StarFire/Core/BitField.h"
-
-
+#define SST_USER_NAMESPACE StarFire
+#include "Substrate/BitField.h"
+#undef SST_USER_NAMESPACE
 #include <string>
 #include <functional>
-
 
 namespace StarFire {
 
 	enum class EventType
 	{
 		NONE = 0,
-		WINDOW_CLOSE, 
+		WINDOW_CLOSE,
 		WINDOW_MINIMIZE,
 		WINDOW_RESIZE,
 		WINDOW_FOCUS,
@@ -34,16 +33,17 @@ namespace StarFire {
 		MOUSE_SCROLLED
 	};
 
-	enum class EventCategory : BitField8
+	enum class EventCategory : Substrate::BitField8
 	{
-		NONE			= 0,
-		APPLICATION		= BIT(0),
-		INPUT			= BIT(1),
-		KEYBOARD		= BIT(2),
-		MOUSE			= BIT(3),
-		MOUSE_BUTTON	= BIT(4)
+		NONE = 0,
+		APPLICATION = BIT(0),
+		INPUT = BIT(1),
+		KEYBOARD = BIT(2),
+		MOUSE = BIT(3),
+		MOUSE_BUTTON = BIT(4)
 	};
-	SF_ENABLE_BIT_OPS(EventCategory);
+	SST_ENABLE_BIT_OPS(EventCategory);
+	
 
 #define EVENT_CLASS_TYPE(type) static EventType GetStaticType() { return EventType::##type; }\
 								virtual EventType GetEventType() const override { return GetStaticType(); }\
@@ -64,7 +64,7 @@ namespace StarFire {
 		virtual bool IsCoalescent() const = 0;
 		virtual std::string ToString() const { return GetName(); }
 
-		inline bool IsInCategory(EventCategory category) { return FieldHasFlag(GetCategoryFlags(), category); }
+		inline bool IsInCategory(EventCategory category) { return Substrate::FieldHasFlag(GetCategoryFlags(), category); }
 
 	public:
 		bool Handled = false;

--- a/Substrate/Include/Substrate/BitField.h
+++ b/Substrate/Include/Substrate/BitField.h
@@ -39,85 +39,103 @@
 
 #include<type_traits>
 
-namespace StarFire {
-		using BitField8 = uint8_t;
-		using BitField16 = uint16_t;
-		using BitField32 = uint32_t;
-		using BitField64 = uint64_t;
+#if defined(SST_USER_NAMESPACE)
+#define USER_NAMESPACE_BEGIN namespace SST_USER_NAMESPACE {
+#define USER_NAMESPACE_END }
+#else
+#define USER_NAMESPACE_BEGIN
+#define USER_NAMESPACE_END
+#endif
 
+USER_NAMESPACE_BEGIN
+namespace Substrate {
+
+	using BitField8 = uint8_t;
+	using BitField16 = uint16_t;
+	using BitField32 = uint32_t;
+	using BitField64 = uint64_t;
+
+	/// Utility macro to define bit values
 #define BIT(x) (1 << x)
-
-#define SF_ENABLE_BIT_OPS(Name) template<> struct enable_bitmask_operators<Name>{ static constexpr bool enable = true; }
-
+	/// Macro to enable bitwise operators for a specific enum class. This also imports the operators into the current namespace.		
+#define SST_ENABLE_BIT_OPS(Name)\
+	namespace Substrate { template<> struct enable_bitmask_operators<Name> { static constexpr bool enable = true; }; }\
+	using Substrate::operator|;\
+	using Substrate::operator&;\
+	using Substrate::operator^;\
+	using Substrate::operator~;\
+	using Substrate::operator|=;\
+	using Substrate::operator&=;\
+	using Substrate::operator^=;
 
 	//From https://www.justsoftwaresolutions.co.uk/cplusplus/using-enum-classes-as-bitfields.html with adjustments (constexpr)
 
 	template<typename T>
 	struct enable_bitmask_operators {
-		static constexpr bool enable = false;
+	static constexpr bool enable = false;
 	};
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-		operator|(E lhs, E rhs) {
-		typedef typename std::underlying_type<E>::type underlying;
-		return static_cast<E>(
-			static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
+	operator|(E lhs, E rhs) {
+	typedef typename std::underlying_type<E>::type underlying;
+	return static_cast<E>(
+		static_cast<underlying>(lhs) | static_cast<underlying>(rhs));
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-		operator&(E lhs, E rhs) {
-		typedef typename std::underlying_type<E>::type underlying;
-		return static_cast<E>(
-			static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
+	operator&(E lhs, E rhs) {
+	typedef typename std::underlying_type<E>::type underlying;
+	return static_cast<E>(
+		static_cast<underlying>(lhs) & static_cast<underlying>(rhs));
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-		operator^(E lhs, E rhs) {
-		typedef typename std::underlying_type<E>::type underlying;
-		return static_cast<E>(
-			static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
+	operator^(E lhs, E rhs) {
+	typedef typename std::underlying_type<E>::type underlying;
+	return static_cast<E>(
+		static_cast<underlying>(lhs) ^ static_cast<underlying>(rhs));
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E>::type
-		operator~(E lhs) {
-		typedef typename std::underlying_type<E>::type underlying;
-		return static_cast<E>(
-			~static_cast<underlying>(lhs));
+	operator~(E lhs) {
+	typedef typename std::underlying_type<E>::type underlying;
+	return static_cast<E>(
+		~static_cast<underlying>(lhs));
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E&>::type
-		operator|=(E& lhs, E rhs) {
-		lhs = lhs | rhs;
-		return lhs;
+	operator|=(E& lhs, E rhs) {
+	lhs = lhs | rhs;
+	return lhs;
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E&>::type
-		operator&=(E& lhs, E rhs) {
-		lhs = lhs & rhs;
-		return lhs;
+	operator&=(E& lhs, E rhs) {
+	lhs = lhs & rhs;
+	return lhs;
 	}
 
 	template<typename E>
 	constexpr std::enable_if<enable_bitmask_operators<E>::enable, E&>::type
-		operator^=(E& lhs, E rhs) {
-		lhs = lhs ^ rhs;
-		return lhs;
+	operator^=(E& lhs, E rhs) {
+	lhs = lhs ^ rhs;
+	return lhs;
 	}
 
 	//Added:
 	template<typename E>
 	constexpr bool FieldHasFlag(E field, E flag)
 	{
-		static_assert(enable_bitmask_operators<E>::enable, "hasFlag requires a bitfield-operator enabled bitfield");
-		using underlying = std::underlying_type_t<E>;
-		return (static_cast<underlying>(field) & static_cast<underlying>(flag)) == static_cast<underlying>(flag);
+	static_assert(enable_bitmask_operators<E>::enable, "hasFlag requires a bitfield-operator enabled bitfield");
+	using underlying = std::underlying_type_t<E>;
+	return (static_cast<underlying>(field) & static_cast<underlying>(flag)) == static_cast<underlying>(flag);
 	}
 
-	
 }
+USER_NAMESPACE_END


### PR DESCRIPTION
### Substrate:
- added BitField

### StarFire:
- removed BitField

Some minor changes to how the Macro specialized the enable_bitmask_operators template because of namespace shenanigans